### PR TITLE
Add `foldl`, `map`, etc. for traversing arrays

### DIFF
--- a/lib/fn/fold.lua
+++ b/lib/fn/fold.lua
@@ -15,6 +15,16 @@ function fold.foldl(f, m, t)
   return m
 end
 
+--     foldl(f,[a,b,c]) --> f(f(a,b),c)
+--
+function fold.foldl1(f, t)
+  local m
+  for i, v in ipairs(t) do
+    m = (i == 1 and v or f(m, v))
+  end
+  return m
+end
+
 --------------------------------------------------------------------------------
 -- Right-fold a binary function over an array of elements using ipairs
 --
@@ -34,5 +44,7 @@ function fold.foldr(f, m, t)
 
   return caller(m, start)
 end
+
+
 
 return fold

--- a/lib/fn/fold.lua
+++ b/lib/fn/fold.lua
@@ -55,7 +55,7 @@ function fold.foldr1(f, t)
     if v == nil then
       return nil
     else
-      Local rhs = caller(i)
+      local rhs = caller(i)
       return rhs and f(v, rhs) or v
     end
   end

--- a/lib/fn/fold.lua
+++ b/lib/fn/fold.lua
@@ -1,0 +1,8 @@
+-- Folds
+
+local fold = {}
+
+-- foldl
+-- foldr
+
+return fold

--- a/lib/fn/fold.lua
+++ b/lib/fn/fold.lua
@@ -45,6 +45,22 @@ function fold.foldr(f, m, t)
   return caller(m, start)
 end
 
+--     foldr1(f,[a,b,c]) --> f(a,f(b,c))
+--
+function fold.foldr1(f, t)
+  local iter, _, start = ipairs(t)
 
+  function caller(i)
+    local i, v = iter(t, i)
+    if v == nil then
+      return nil
+    else
+      Local rhs = caller(i)
+      return rhs and f(v, rhs) or v
+    end
+  end
+
+  return caller(start)
+end
 
 return fold

--- a/lib/fn/fold.lua
+++ b/lib/fn/fold.lua
@@ -2,7 +2,37 @@
 
 local fold = {}
 
--- foldl
--- foldr
+--------------------------------------------------------------------------------
+-- Left-fold a binary function over an array of elements using ipairs
+--
+--     foldl(f,m,[a,b,c]) --> f(f(f(m,a),b),c)
+--
+function fold.foldl(f, m, t)
+  local m = m
+  for _, v in ipairs(t) do
+    m = f(m, v)
+  end
+  return m
+end
+
+--------------------------------------------------------------------------------
+-- Right-fold a binary function over an array of elements using ipairs
+--
+--     foldr(f,m,[a,b,c]) --> f(a,f(b,f(c,m)))
+--
+function fold.foldr(f, m, t)
+  local iter, _, start = ipairs(t)
+
+  function caller(m, i)
+    local i, v = iter(t, i)
+    if v == nil then
+      return m
+    else
+      return f(v, caller(m, i))
+    end
+  end
+
+  return caller(m, start)
+end
 
 return fold

--- a/lib/fn/init.lua
+++ b/lib/fn/init.lua
@@ -3,6 +3,8 @@ local fn = {}
 fn.funct = require 'fn.funct'
 fn.ops = require 'fn.ops'
 fn.seq = require 'fn.seq'
+fn.fold = require 'fn.fold'
+fn.trav = require 'fn.trav'
 
 -- identity function
 function fn.id(...) return ... end

--- a/lib/fn/init.lua
+++ b/lib/fn/init.lua
@@ -97,37 +97,4 @@ end
 --
 fn.negate = fn.curry(fn.composit, fn.ops.NOT)
 
---------------------------------------------------------------------------------
--- Left-fold a binary function over an array of elements using ipairs
---
---     foldl(f,m,[a,b,c]) --> f(f(f(m,a),b),c)
---
-function fn.foldl(m, t, f)
-  local m = m
-  for _, v in ipairs(t) do
-    m = f(m, v)
-  end
-  return m
-end
-
---------------------------------------------------------------------------------
--- Right-fold a binary function over an array of elements using ipairs
---
---     foldr(f,m,[a,b,c]) --> f(a,f(b,f(c,m)))
---
-function fn.foldr(f, m, t)
-  local iter, _, start = ipairs(t)
-
-  function caller(m, i)
-    local i, v = iter(t, i)
-    if v == nil then
-      return m
-    else
-      return f(v, caller(m, i))
-    end
-  end
-
-  return caller(m, start)
-end
-
 return fn

--- a/lib/fn/trav.lua
+++ b/lib/fn/trav.lua
@@ -19,7 +19,7 @@ end
 function trav.map(f, t)
   local r = {}
   for k,v in ipairs(t) do
-    r[k] = f(r)
+    r[k] = f(v)
   end
   return r
 end

--- a/lib/fn/trav.lua
+++ b/lib/fn/trav.lua
@@ -24,6 +24,11 @@ function trav.map(f, t)
   return r
 end
 
+-- count
+function trav.count(t)
+  return #(t)
+end
+
 -- sum
 trav.sum = fold.foldl1/ops.add
 

--- a/lib/fn/trav.lua
+++ b/lib/fn/trav.lua
@@ -1,6 +1,13 @@
 -- Methods for traversing arrays
 
+local funct = require 'fn.funct'
+local fold = require 'fn.fold'
+
+local trav = {}
+
 -- elem (search)
 -- map
 -- sum
 -- product: foldl/op"*"
+
+return trav

--- a/lib/fn/trav.lua
+++ b/lib/fn/trav.lua
@@ -25,6 +25,9 @@ function trav.map(f, t)
 end
 
 -- sum
--- product: foldl/op"*"
+trav.sum = fold.foldl1/ops.add
+
+-- product
+trav.product = fold.foldl1/ops.mul
 
 return trav

--- a/lib/fn/trav.lua
+++ b/lib/fn/trav.lua
@@ -1,0 +1,6 @@
+-- Methods for traversing arrays
+
+-- elem (search)
+-- map
+-- sum
+-- product: foldl/op"*"

--- a/lib/fn/trav.lua
+++ b/lib/fn/trav.lua
@@ -6,7 +6,24 @@ local fold = require 'fn.fold'
 local trav = {}
 
 -- elem (search)
+function trav.elem(e, t)
+  for _,v in ipairs(t) do
+    if v == e then
+      return true
+    end
+  end
+  return false
+end
+
 -- map
+function trav.map(f, t)
+  local r = {}
+  for k,v in ipairs(t) do
+    r[k] = f(r)
+  end
+  return r
+end
+
 -- sum
 -- product: foldl/op"*"
 

--- a/lib/fn/trav.lua
+++ b/lib/fn/trav.lua
@@ -2,6 +2,7 @@
 
 local funct = require 'fn.funct'
 local fold = require 'fn.fold'
+local ops = require 'fn.ops'
 
 local trav = {}
 

--- a/spec/fold_spec.lua
+++ b/spec/fold_spec.lua
@@ -30,7 +30,7 @@ describe("fold", function()
     assert.equal(10, fold.foldr1(_add, {1,2,3,4}))
     assert.equal(4, fold.foldr1(_div, {8,12,24,4}))
     assert.equal(12, fold.foldr1(_div, {12}))
-    assert.equal(true, fold.foldr1(_or, true, {false,true,false,true}))
+    assert.equal(true, fold.foldr1(_or, {false,true,false,true}))
   end)
 
 end)

--- a/spec/fold_spec.lua
+++ b/spec/fold_spec.lua
@@ -2,33 +2,35 @@ require 'spec.setup'
 
 local fold = require 'fn.fold'
 
+local function _add(a,b) return a+b end
+local function _div(a,b) return a/b end
+local function _or(a,b) return a or b end
+
 describe("fold", function()
   it("can fold left over elements", function()
-    local function _div(a,b) return a/b end
     assert.equal(2, fold.foldl(_div, 64, {4,2,4}))
     assert.equal(3, fold.foldl(_div, 3, {}))
+    assert.equal(true, fold.foldl(_or, true, {false,true,false,true}))
   end)
   
   it("can fold right over elements", function()
-    local function _div(a,b) return a/b end
     assert.equal(8, fold.foldr(_div, 2, {8,12,24,4}))
     assert.equal(3, fold.foldr(_div, 3, {}))
+    assert.equal(true, fold.foldr(_or, true, {false,true,false,true}))
   end)
 
   it("can fold left over elements with no base", function()
-    local function _add(a,b) return a+b end
-    local function _div(a,b) return a/b end
     assert.equal(10, fold.foldl1(_add, {1,2,3,4}))
     assert.equal(1, fold.foldl1(_div, {64,4,2,8}))
     assert.equal(12, fold.foldl1(_div, {12}))
+    assert.equal(true, fold.foldl1(_or, {false,true,false,true}))
   end)
 
   it("can fold right over elements with no base", function()
-    local function _add(a,b) return a+b end
-    local function _div(a,b) return a/b end
     assert.equal(10, fold.foldr1(_add, {1,2,3,4}))
     assert.equal(4, fold.foldr1(_div, {8,12,24,4}))
     assert.equal(12, fold.foldr1(_div, {12}))
+    assert.equal(true, fold.foldr1(_or, true, {false,true,false,true}))
   end)
 
 end)

--- a/spec/fold_spec.lua
+++ b/spec/fold_spec.lua
@@ -1,0 +1,5 @@
+require 'spec.setup'
+
+local fold = require 'fn.fold'
+
+-- TODO

--- a/spec/fold_spec.lua
+++ b/spec/fold_spec.lua
@@ -14,4 +14,21 @@ describe("fold", function()
     assert.equal(8, fold.foldr(_div, 2, {8,12,24,4}))
     assert.equal(3, fold.foldr(_div, 3, {}))
   end)
+
+  it("can fold left over elements with no base", function()
+    local function _add(a,b) return a+b end
+    local function _div(a,b) return a/b end
+    assert.equal(10, fold.foldl1(_add, {1,2,3,4}))
+    assert.equal(1, fold.foldl1(_div, {64,4,2,8}))
+    assert.equal(12, fold.foldl1(_div, {12}))
+  end)
+
+  it("can fold right over elements with no base", function()
+    local function _add(a,b) return a+b end
+    local function _div(a,b) return a/b end
+    assert.equal(10, fold.foldr1(_add, {1,2,3,4}))
+    assert.equal(4, fold.foldr1(_div, {8,12,24,4}))
+    assert.equal(12, fold.foldr1(_div, {12}))
+  end)
+
 end)

--- a/spec/fold_spec.lua
+++ b/spec/fold_spec.lua
@@ -2,4 +2,16 @@ require 'spec.setup'
 
 local fold = require 'fn.fold'
 
--- TODO
+describe("fold", function()
+  it("can fold left over elements", function()
+    local function _div(a,b) return a/b end
+    assert.equal(2, fold.foldl(_div, 64, {4,2,4}))
+    assert.equal(3, fold.foldl(_div, 3, {}))
+  end)
+  
+  it("can fold right over elements", function()
+    local function _div(a,b) return a/b end
+    assert.equal(8, fold.foldr(_div, 2, {8,12,24,4}))
+    assert.equal(3, fold.foldr(_div, 3, {}))
+  end)
+end)

--- a/spec/trav_spec.lua
+++ b/spec/trav_spec.lua
@@ -2,4 +2,27 @@ require 'spec.setup'
 
 local trav = require 'fn.trav'
 
--- TODO
+describe("trav", function()
+  it("can search for elements", function()
+    assert.equal(true, trav.elem(2, {4,3,2,1}))
+    assert.equal(false, trav.elem(10, {4,3,2,1}))
+    assert.equal(false, trav.elem(2, {}))
+  end)
+  
+  it("can count up elements", function()
+    assert.equal(4, trav.count({4,3,2,1}))
+    assert.equal(0, trav.count({}))
+  end)
+  
+  it("can map a function onto each element", function()
+    assert.are.same({"4","3","2","1"}, trav.map(tostring, {4,3,2,1}))
+  end)
+  
+  it("can add up all members", function()
+    assert.equal(10, trav.sum({4,3,2,1}))
+  end)
+  
+  it("can multiply all members", function()
+    assert.equal(24, trav.product({4,3,2,1}))
+  end)
+end)

--- a/spec/trav_spec.lua
+++ b/spec/trav_spec.lua
@@ -1,0 +1,5 @@
+require 'spec.setup'
+
+local trav = require 'fn.trav'
+
+-- TODO


### PR DESCRIPTION
`fn.fold`
- [x] foldl
- [x] foldr
- [x] foldl1
- [x] foldr1

`fn.trav`
- [x] elem
- [x] count
- [x] map
- [x] sum
- [x] product
